### PR TITLE
Add version 2 constraint for savon to gemspec

### DIFF
--- a/cellular.gemspec
+++ b/cellular.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'savon'
+  gem.add_dependency 'savon', '~> 2.0'
 
   gem.add_development_dependency 'pry'
 end


### PR DESCRIPTION
Savon 3 changes some things including requiring WSDLs and removing
some dependencies. It's probably a good idea to have a pessimistic
constraint for Savon 2.x to avoid surprises.
