### PR TITLE
Feature/bulk sending of sms

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ sms = Cellular::SMS.new(
 
 sms.deliver
 ```
-For use with multiple recipients in one request use
+For use with multiple recipients in one request use:
 
 ```ruby
 sms = Cellular::SMS.new(

--- a/README.md
+++ b/README.md
@@ -66,7 +66,19 @@ sms = Cellular::SMS.new(
 
 sms.deliver
 ```
+For use with multiple recipients in one request use
 
+```ruby
+sms = Cellular::SMS.new(
+  recipients: ['47xxxxxxx1','47xxxxxxx2','47xxxxxxx3'],
+  sender: 'Custom sender',
+  message: 'This is an SMS message',
+  price: 0,
+  country_code: 'NO' # defaults to Cellular.config.country_code
+)
+
+sms.deliver
+```
 You can also use Sidekiq to send texts, which is great if you're in a Rails app
 and are concerned that it might time out or something. Actually, if you have
 Sidekiq at your disposal, it's a great idea anyway! To use it, just call

--- a/lib/cellular/backends/cool_sms.rb
+++ b/lib/cellular/backends/cool_sms.rb
@@ -11,7 +11,8 @@ module Cellular
         request_queue = {}
 
         receipients_batch(options).each_with_index do |recipient, index|
-          result = HTTParty.get(GATEWAY_URL, query: payload(options, recipient) )
+          options[:batch] = recipient
+          result = HTTParty.get(GATEWAY_URL, query: defaults_with(options) )
           request_queue[index] = {
             recipient: recipient,
             response: parse_response(result.parsed_response['smsc'])
@@ -36,10 +37,10 @@ module Cellular
         }
       end
 
-      def self.payload(options, recipient)
+      def self.defaults_with(options)
         {
           from: options[:sender],
-          to: options[:recipient],
+          to: options[:batch],
           message: options[:message],
           charset: 'utf-8',
           resulttype: 'xml',

--- a/lib/cellular/backends/cool_sms.rb
+++ b/lib/cellular/backends/cool_sms.rb
@@ -8,24 +8,33 @@ module Cellular
       GATEWAY_URL = 'https://sms.coolsmsc.dk/'
 
       def self.deliver(options = {})
-        query = {
+        result = HTTParty.get(GATEWAY_URL, query: payload(options) )
+        parse_response(result.parsed_response['smsc'])
+      end
+
+      def self.parse_response(response)
+        [
+          response['status'],
+          response['result'] || response['message']['result']
+        ]
+      end
+
+      def self.coolsms_config
+        {
           username: Cellular.config.username,
-          password: Cellular.config.password,
+          password: Cellular.config.password
+        }
+      end
+
+      def self.payload(options)
+        {
           from: options[:sender],
           to: options[:recipient],
           message: options[:message],
           charset: 'utf-8',
           resulttype: 'xml',
           lang: 'en'
-        }
-
-        result = HTTParty.get(GATEWAY_URL, query: query)
-        response = result.parsed_response['smsc']
-
-        [
-          response['status'],
-          response['result'] || response['message']['result']
-        ]
+        }.merge!(coolsms_config)
       end
 
     end

--- a/lib/cellular/backends/cool_sms.rb
+++ b/lib/cellular/backends/cool_sms.rb
@@ -10,7 +10,7 @@ module Cellular
       def self.deliver(options = {})
         request_queue = {}
 
-        receipients_batch(options).each_with_index do |recipient, index|
+        recipients_batch(options).each_with_index do |recipient, index|
           options[:batch] = recipient
           result = HTTParty.get(GATEWAY_URL, query: defaults_with(options) )
           request_queue[index] = {
@@ -48,11 +48,11 @@ module Cellular
         }.merge!(coolsms_config)
       end
 
-      def self.receipients_batch(options)
-        if options[:receipients].blank?
+      def self.recipients_batch(options)
+        if options[:recipients].blank?
           [options[:recipient]]
         else
-          options[:receipients]
+          options[:recipients]
         end
       end
 

--- a/lib/cellular/backends/cool_sms.rb
+++ b/lib/cellular/backends/cool_sms.rb
@@ -8,18 +8,18 @@ module Cellular
       GATEWAY_URL = 'https://sms.coolsmsc.dk/'
 
       def self.deliver(options = {})
-        request_que = {}
+        request_queue = {}
 
         recipients_batch(options).each_with_index do |recipient, _index|
           result = HTTParty.get(GATEWAY_URL, query: payload(options, recipient) )
-          request_que[_index] = {
+          request_queue[_index] = {
             recipient: recipient,
             response: parse_response(result.parsed_response['smsc'])
           }
         end
 
         # return first response for now
-        request_que[0][:response]
+        request_queue[0][:response]
       end
 
       def self.parse_response(response)

--- a/lib/cellular/backends/cool_sms.rb
+++ b/lib/cellular/backends/cool_sms.rb
@@ -10,9 +10,9 @@ module Cellular
       def self.deliver(options = {})
         request_queue = {}
 
-        recipients_batch(options).each_with_index do |recipient, _index|
+        recipients_batch(options).each_with_index do |recipient, index|
           result = HTTParty.get(GATEWAY_URL, query: payload(options, recipient) )
-          request_queue[_index] = {
+          request_queue[index] = {
             recipient: recipient,
             response: parse_response(result.parsed_response['smsc'])
           }

--- a/lib/cellular/backends/cool_sms.rb
+++ b/lib/cellular/backends/cool_sms.rb
@@ -10,7 +10,7 @@ module Cellular
       def self.deliver(options = {})
         request_queue = {}
 
-        recipients_batch(options).each_with_index do |recipient, index|
+        receipients_batch(options).each_with_index do |recipient, index|
           result = HTTParty.get(GATEWAY_URL, query: payload(options, recipient) )
           request_queue[index] = {
             recipient: recipient,
@@ -47,7 +47,7 @@ module Cellular
         }.merge!(coolsms_config)
       end
 
-      def self.recipients_batch(options)
+      def self.receipients_batch(options)
         if options[:receipients].blank?
           [options[:recipient]]
         else

--- a/lib/cellular/backends/sendega.rb
+++ b/lib/cellular/backends/sendega.rb
@@ -38,27 +38,7 @@ module Cellular
 
         client = Savon.client savon_options
 
-        result = client.call(:send, message: {
-            username: Cellular.config.username,
-            password: Cellular.config.password,
-            sender: options[:sender],
-            destination: options[:recipient],
-            pricegroup: options[:price] || 0, # default price to 0
-            contentTypeID: 1,
-            contentHeader: '',
-            content: options[:message],
-            dlrUrl: Cellular.config.delivery_url,
-            ageLimit: 0,
-            extID: '',
-            sendDate: '',
-            refID: '',
-            priority: 0,
-            gwID: 0,
-            pid: 0,
-            dcs: 0
-          }
-        )
-
+        result = client.call(:send, message: payload(options) )
         body = result.body[:send_response][:send_result]
 
         if body[:success]
@@ -76,6 +56,33 @@ module Cellular
 
       def self.receive(data)
         raise NotImplementedError
+      end
+
+      def self.savon_config
+        {
+           username: Cellular.config.username,
+           password: Cellular.config.password,
+           dlrUrl: Cellular.config.delivery_url
+        }
+      end
+
+      def self.payload(options)
+       {
+          sender: options[:sender],
+          destination: options[:recipient],
+          pricegroup: options[:price] || 0, # default price to 0
+          contentTypeID: 1,
+          contentHeader: '',
+          content: options[:message],
+          ageLimit: 0,
+          extID: '',
+          sendDate: '',
+          refID: '',
+          priority: 0,
+          gwID: 0,
+          pid: 0,
+          dcs: 0
+        }.merge!(savon_config)
       end
 
     end

--- a/lib/cellular/backends/sendega.rb
+++ b/lib/cellular/backends/sendega.rb
@@ -38,7 +38,7 @@ module Cellular
         request_queue = {}
         client = Savon.client savon_options
 
-        receipients_batch(options).each_with_index do |batch, index|
+        recipients_batch(options).each_with_index do |batch, index|
           options[:batch] = batch
           result = client.call(:send, message: defaults_with(options))
 
@@ -94,11 +94,11 @@ module Cellular
         'Message is received and is being processed.'
       end
 
-      def self.receipients_batch(options)
-        if options[:receipients].blank?
+      def self.recipients_batch(options)
+        if options[:recipients].blank?
           [options[:recipient]]
         else
-          options[:receipients].each_slice(100).to_a.map{|x| x.join(',') }
+          options[:recipients].each_slice(100).to_a.map{|x| x.join(',') }
         end
       end
 

--- a/lib/cellular/backends/sendega.rb
+++ b/lib/cellular/backends/sendega.rb
@@ -39,7 +39,8 @@ module Cellular
         client = Savon.client savon_options
 
         receipients_batch(options).each_with_index do |batch, index|
-          result = client.call(:send, message: payload(options, batch))
+          options[:batch] = batch
+          result = client.call(:send, message: defaults_with(options))
 
           request_queue[index] = {
             batch: batch,
@@ -65,10 +66,10 @@ module Cellular
         }
       end
 
-      def self.payload(options, recipients)
+      def self.defaults_with(options)
        {
           sender: options[:sender],
-          destination: recipients,
+          destination: options[:batch],
           pricegroup: options[:price] || 0, # default price to 0
           contentTypeID: 1,
           contentHeader: '',

--- a/lib/cellular/backends/sendega.rb
+++ b/lib/cellular/backends/sendega.rb
@@ -35,13 +35,13 @@ module Cellular
         # http://controlpanel.sendega.no/Content/Sendega%20-%20API%20documentation%20v2.3.pdf
 
         savon_options[:wsdl] = GATEWAY_URL
-        request_que = {}
+        request_queue = {}
         client = Savon.client savon_options
 
         recipients_batch(options).each_with_index do |_batch, _index|
           result = client.call(:send, message: payload(options, _batch))
 
-          request_que[_index] = {
+          request_queue[_index] = {
             batch: _batch,
             result: result,
             body:result.body[:send_response][:send_result],
@@ -50,7 +50,7 @@ module Cellular
         end
 
         # for now just resturn first response
-        request_que[0][:response]
+        request_queue[0][:response]
       end
 
       def self.receive(data)

--- a/lib/cellular/backends/sendega.rb
+++ b/lib/cellular/backends/sendega.rb
@@ -38,11 +38,11 @@ module Cellular
         request_queue = {}
         client = Savon.client savon_options
 
-        recipients_batch(options).each_with_index do |_batch, _index|
-          result = client.call(:send, message: payload(options, _batch))
+        recipients_batch(options).each_with_index do |batch, index|
+          result = client.call(:send, message: payload(options, batch))
 
-          request_queue[_index] = {
-            batch: _batch,
+          request_queue[index] = {
+            batch: batch,
             result: result,
             body:result.body[:send_response][:send_result],
             response: map_response(result.body[:send_response][:send_result])

--- a/lib/cellular/backends/sendega.rb
+++ b/lib/cellular/backends/sendega.rb
@@ -38,7 +38,7 @@ module Cellular
         request_queue = {}
         client = Savon.client savon_options
 
-        recipients_batch(options).each_with_index do |batch, index|
+        receipients_batch(options).each_with_index do |batch, index|
           result = client.call(:send, message: payload(options, batch))
 
           request_queue[index] = {
@@ -93,7 +93,7 @@ module Cellular
         'Message is received and is being processed.'
       end
 
-      def self.recipients_batch(options)
+      def self.receipients_batch(options)
         if options[:receipients].blank?
           [options[:recipient]]
         else

--- a/lib/cellular/backends/sendega.rb
+++ b/lib/cellular/backends/sendega.rb
@@ -40,18 +40,7 @@ module Cellular
 
         result = client.call(:send, message: payload(options) )
         body = result.body[:send_response][:send_result]
-
-        if body[:success]
-          [
-            body[:error_number].to_i,
-            'Message is received and is being processed.'
-          ]
-        else
-          [
-            body[:error_number].to_i,
-            body[:error_message]
-          ]
-        end
+        map_response(body)
       end
 
       def self.receive(data)
@@ -83,6 +72,15 @@ module Cellular
           pid: 0,
           dcs: 0
         }.merge!(savon_config)
+      end
+
+      def self.map_response(_body)
+        msg = _body[:success] ?  success_message : _body[:error_message]
+        [ _body[:error_number].to_i, msg ]
+      end
+
+      def self.success_message
+        'Message is received and is being processed.'
       end
 
     end

--- a/lib/cellular/models/sms.rb
+++ b/lib/cellular/models/sms.rb
@@ -2,10 +2,11 @@ module Cellular
   class SMS
 
     attr_accessor :recipient, :sender, :message, :price, :country_code
-
+    attr_accessor :recipients
     def initialize(options = {})
       @backend = Cellular.config.backend
 
+      @recipients = options[:recipients]
       @recipient = options[:recipient]
       @sender = options[:sender] || Cellular.config.sender
       @message = options[:message]
@@ -54,6 +55,7 @@ module Cellular
 
     def options
       {
+        recipients: @recipients,
         recipient: @recipient,
         sender: @sender,
         message: @message,

--- a/spec/cellular/backends/cool_sms_spec.rb
+++ b/spec/cellular/backends/cool_sms_spec.rb
@@ -92,9 +92,10 @@ describe Cellular::Backends::CoolSMS do
     end
   end
 
-  describe '::payload' do
+  describe '::defaults_with' do
     it 'should return the whole query' do
-      expect(described_class.payload(options, recipient: recipient)).to eq(payload)
+      options[:batch] = recipient
+      expect(described_class.defaults_with(options)).to eq(payload)
     end
   end
 

--- a/spec/cellular/backends/cool_sms_spec.rb
+++ b/spec/cellular/backends/cool_sms_spec.rb
@@ -94,9 +94,19 @@ describe Cellular::Backends::CoolSMS do
 
   describe 'payload' do
     it 'should return the whole query' do
-      expect(described_class.payload(options)).to eq(payload)
+      expect(described_class.payload(options, recipient: recipient)).to eq(payload)
     end
   end
 
+  describe 'recipients_batch' do
+    it 'should wrap recipient option into a array' do
+      expect(described_class.recipients_batch({recipient: recipient}))
+        .to eq([recipient])
+    end
+    it 'should return recipients option as it is' do
+      expect(described_class.recipients_batch({receipients: [recipient,recipient]}))
+        .to eq([recipient,recipient])
+    end
+  end
 
 end

--- a/spec/cellular/backends/cool_sms_spec.rb
+++ b/spec/cellular/backends/cool_sms_spec.rb
@@ -14,7 +14,7 @@ describe Cellular::Backends::CoolSMS do
     }
   }
 
-  let(:payload){
+  let(:payload) {
     {
       username: 'username',
       password: 'password',

--- a/spec/cellular/backends/cool_sms_spec.rb
+++ b/spec/cellular/backends/cool_sms_spec.rb
@@ -99,13 +99,13 @@ describe Cellular::Backends::CoolSMS do
     end
   end
 
-  describe '::receipients_batch' do
+  describe '::recipients_batch' do
     it 'should wrap recipient option into a array' do
-      expect(described_class.receipients_batch({recipient: recipient}))
+      expect(described_class.recipients_batch({recipient: recipient}))
         .to eq([recipient])
     end
     it 'should return recipients option as it is' do
-      expect(described_class.receipients_batch({receipients: [recipient,recipient]}))
+      expect(described_class.recipients_batch({recipients: [recipient,recipient]}))
         .to eq([recipient,recipient])
     end
   end

--- a/spec/cellular/backends/cool_sms_spec.rb
+++ b/spec/cellular/backends/cool_sms_spec.rb
@@ -69,7 +69,7 @@ describe Cellular::Backends::CoolSMS do
     end
   end
 
-  describe 'parse_response' do
+  describe '::parse_response' do
     it 'should return the correct response' do
       message = ['success', 'The message was sent correctly.']
 
@@ -82,7 +82,7 @@ describe Cellular::Backends::CoolSMS do
     end
   end
 
-  describe 'coolsms_config' do
+  describe '::coolsms_config' do
     it 'should return the config for coolsms' do
       expect(described_class.coolsms_config).to eq(
         {
@@ -92,13 +92,13 @@ describe Cellular::Backends::CoolSMS do
     end
   end
 
-  describe 'payload' do
+  describe '::payload' do
     it 'should return the whole query' do
       expect(described_class.payload(options, recipient: recipient)).to eq(payload)
     end
   end
 
-  describe 'recipients_batch' do
+  describe '::recipients_batch' do
     it 'should wrap recipient option into a array' do
       expect(described_class.recipients_batch({recipient: recipient}))
         .to eq([recipient])

--- a/spec/cellular/backends/cool_sms_spec.rb
+++ b/spec/cellular/backends/cool_sms_spec.rb
@@ -98,13 +98,13 @@ describe Cellular::Backends::CoolSMS do
     end
   end
 
-  describe '::recipients_batch' do
+  describe '::receipients_batch' do
     it 'should wrap recipient option into a array' do
-      expect(described_class.recipients_batch({recipient: recipient}))
+      expect(described_class.receipients_batch({recipient: recipient}))
         .to eq([recipient])
     end
     it 'should return recipients option as it is' do
-      expect(described_class.recipients_batch({receipients: [recipient,recipient]}))
+      expect(described_class.receipients_batch({receipients: [recipient,recipient]}))
         .to eq([recipient,recipient])
     end
   end

--- a/spec/cellular/backends/sendega_spec.rb
+++ b/spec/cellular/backends/sendega_spec.rb
@@ -130,14 +130,14 @@ describe Cellular::Backends::Sendega do
     end
   end
 
-  describe '::receipients_batch' do
+  describe '::recipients_batch' do
     it 'should split recipients into arrays of 100 then join them with ,' do
-      check = described_class.receipients_batch({receipients:recipients}).length
+      check = described_class.recipients_batch({recipients:recipients}).length
       expect(check).to eq 3
     end
 
     it 'should put recipient into one array' do
-      check = described_class.receipients_batch({receipient:recipient}).length
+      check = described_class.recipients_batch({receipient:recipient}).length
       expect(check).to eq 1
     end
   end

--- a/spec/cellular/backends/sendega_spec.rb
+++ b/spec/cellular/backends/sendega_spec.rb
@@ -2,13 +2,13 @@ require 'spec_helper'
 
 describe Cellular::Backends::Sendega do
 
-  let(:recipient) { '47xxxxxxxx' }
-  let(:sender)    { 'Custom sender' }
-  let(:message)   { 'This is an SMS message' }
-  let(:price)     { 100 }
-  let(:country)   { 'NO '}
-  let(:recipients){ (1..300).to_a.map!{|n| "47xxxxxxx#{n}"} }
-  let(:options) {
+  let(:recipient)  { '47xxxxxxxx' }
+  let(:sender)     { 'Custom sender' }
+  let(:message)    { 'This is an SMS message' }
+  let(:price)      { 100 }
+  let(:country)    { 'NO '}
+  let(:recipients) { (1..300).to_a.map!{|n| "47xxxxxxx#{n}"} }
+  let(:options)    {
     {
       recipient: recipient,
       sender: sender,
@@ -22,7 +22,7 @@ describe Cellular::Backends::Sendega do
     }
   }
 
-  let(:payload){
+  let(:payload) {
     {
       username: Cellular.config.username,
       password: Cellular.config.password,

--- a/spec/cellular/backends/sendega_spec.rb
+++ b/spec/cellular/backends/sendega_spec.rb
@@ -103,7 +103,7 @@ describe Cellular::Backends::Sendega do
     end
   end
 
-  describe 'success_message' do
+  describe '::success_message' do
     it 'should return this message' do
       expect(
         described_class.success_message)
@@ -112,13 +112,13 @@ describe Cellular::Backends::Sendega do
   end
 
 
-  describe 'payload' do
+  describe '::payload' do
     it 'should return the whole payload' do
       expect(described_class.payload(options, recipient)).to eq(payload)
    end
   end
 
-  describe 'savon_config' do
+  describe '::savon_config' do
     it 'should return a hash with config' do
       expect(described_class.savon_config)
       .to eq({
@@ -129,7 +129,7 @@ describe Cellular::Backends::Sendega do
     end
   end
 
-  describe 'recipient_batch' do
+  describe '::recipient_batch' do
     it 'should split recipients into arrays of 100 then join them with ,' do
       check = described_class.recipients_batch({receipients:recipients}).length
       expect(check).to eq 3

--- a/spec/cellular/backends/sendega_spec.rb
+++ b/spec/cellular/backends/sendega_spec.rb
@@ -22,6 +22,28 @@ describe Cellular::Backends::Sendega do
     }
   }
 
+  let(:payload){
+    {
+      username: Cellular.config.username,
+      password: Cellular.config.password,
+      sender: sender,
+      destination: recipient,
+      pricegroup: price,
+      contentTypeID: 1,
+      contentHeader: '',
+      content: message,
+      dlrUrl: nil,
+      ageLimit: 0,
+      extID: '',
+      sendDate: '',
+      refID: '',
+      priority: 0,
+      gwID: 0,
+      pid: 0,
+      dcs: 0
+    }
+  }
+
   before do
     stub_request(:get, described_class::GATEWAY_URL).
       to_return body: fixture('backends/sendega/service.wsdl')
@@ -38,25 +60,8 @@ describe Cellular::Backends::Sendega do
 
       result = double(body: {send_response: {send_result: {}}})
 
-      expect(client).to receive(:call).with(:send, message: {
-        username: Cellular.config.username,
-        password: Cellular.config.password,
-        sender: sender,
-        destination: recipient,
-        pricegroup: price,
-        contentTypeID: 1,
-        contentHeader: '',
-        content: message,
-        dlrUrl: nil,
-        ageLimit: 0,
-        extID: '',
-        sendDate: '',
-        refID: '',
-        priority: 0,
-        gwID: 0,
-        pid: 0,
-        dcs: 0
-      }).and_return result
+      expect(client).to receive(:call).with(:send, message:
+      payload).and_return result
 
       described_class.deliver(options, savon_options)
     end
@@ -109,25 +114,7 @@ describe Cellular::Backends::Sendega do
 
   describe 'payload' do
     it 'should return the whole payload' do
-      expect(described_class.payload(options, recipient)).to eq({
-          username: Cellular.config.username,
-          password: Cellular.config.password,
-          sender: sender,
-          destination: recipient,
-          pricegroup: price,
-          contentTypeID: 1,
-          contentHeader: '',
-          content: message,
-          dlrUrl: nil,
-          ageLimit: 0,
-          extID: '',
-          sendDate: '',
-          refID: '',
-          priority: 0,
-          gwID: 0,
-          pid: 0,
-          dcs: 0
-        })
+      expect(described_class.payload(options, recipient)).to eq(payload)
    end
   end
 

--- a/spec/cellular/backends/sendega_spec.rb
+++ b/spec/cellular/backends/sendega_spec.rb
@@ -112,9 +112,10 @@ describe Cellular::Backends::Sendega do
   end
 
 
-  describe '::payload' do
+  describe '::defaults_with' do
     it 'should return the whole payload' do
-      expect(described_class.payload(options, recipient)).to eq(payload)
+      options[:batch] = recipient
+      expect(described_class.defaults_with(options)).to eq(payload)
    end
   end
 

--- a/spec/cellular/backends/sendega_spec.rb
+++ b/spec/cellular/backends/sendega_spec.rb
@@ -7,7 +7,7 @@ describe Cellular::Backends::Sendega do
   let(:message)   { 'This is an SMS message' }
   let(:price)     { 100 }
   let(:country)   { 'NO '}
-
+  let(:recipients){ (1..300).to_a.map!{|n| "47xxxxxxx#{n}"} }
   let(:options) {
     {
       recipient: recipient,
@@ -98,4 +98,59 @@ describe Cellular::Backends::Sendega do
     end
   end
 
+  describe 'success_message' do
+    it 'should return this message' do
+      expect(
+        described_class.success_message)
+      .to eq 'Message is received and is being processed.'
+    end
+  end
+
+
+  describe 'payload' do
+    it 'should return the whole payload' do
+      expect(described_class.payload(options, recipient)).to eq({
+          username: Cellular.config.username,
+          password: Cellular.config.password,
+          sender: sender,
+          destination: recipient,
+          pricegroup: price,
+          contentTypeID: 1,
+          contentHeader: '',
+          content: message,
+          dlrUrl: nil,
+          ageLimit: 0,
+          extID: '',
+          sendDate: '',
+          refID: '',
+          priority: 0,
+          gwID: 0,
+          pid: 0,
+          dcs: 0
+        })
+   end
+  end
+
+  describe 'savon_config' do
+    it 'should return a hash with config' do
+      expect(described_class.savon_config)
+      .to eq({
+           username: Cellular.config.username,
+           password: Cellular.config.password,
+           dlrUrl: Cellular.config.delivery_url
+        })
+    end
+  end
+
+  describe 'recipient_batch' do
+    it 'should split recipients into arrays of 100 then join them with ,' do
+      check = described_class.recipients_batch({receipients:recipients}).length
+      expect(check).to eq 3
+    end
+
+    it 'should put recipient into one array' do
+      check = described_class.recipients_batch({receipient:recipient}).length
+      expect(check).to eq 1
+    end
+  end
 end

--- a/spec/cellular/backends/sendega_spec.rb
+++ b/spec/cellular/backends/sendega_spec.rb
@@ -129,14 +129,14 @@ describe Cellular::Backends::Sendega do
     end
   end
 
-  describe '::recipient_batch' do
+  describe '::receipients_batch' do
     it 'should split recipients into arrays of 100 then join them with ,' do
-      check = described_class.recipients_batch({receipients:recipients}).length
+      check = described_class.receipients_batch({receipients:recipients}).length
       expect(check).to eq 3
     end
 
     it 'should put recipient into one array' do
-      check = described_class.recipients_batch({receipient:recipient}).length
+      check = described_class.receipients_batch({receipient:recipient}).length
       expect(check).to eq 1
     end
   end

--- a/spec/cellular/models/sms_spec.rb
+++ b/spec/cellular/models/sms_spec.rb
@@ -7,9 +7,11 @@ describe Cellular::SMS do
   let(:message)      { 'This is an SMS message' }
   let(:price)        { 100 }
   let(:country_code) { 'NO'}
+  let(:recipients)   { nil }
 
   subject do
     described_class.new(
+      recipients: recipients,
       recipient: recipient,
       sender: sender,
       message: message,
@@ -63,6 +65,7 @@ describe Cellular::SMS do
   describe '#deliver' do
     before do
       expect(Cellular::Backends::Sendega).to receive(:deliver).with(
+        recipients: recipients,
         recipient: recipient,
         sender: sender,
         price: price,


### PR DESCRIPTION
So this should solve: https://github.com/hyperoslo/cellular/issues/14
* moved some code into methods, making it a little easier to read.
* added recipients option, that should be and array of strings
* added handling of recipients option in backend for sendega and coolsms
* I see now that the feature was just for sendga, but I made it to coolsms also, because its nice to have the option. 
* I have put the responses in a hash, with key for the request number and the recipients it was sent to, and the response. It might come in handy when you actually want to use the response to something. Now both backends just return the first respons in the same way as before.

How do you want to handle responses ?
* Sendenga only supports 100 destinations per request. That means in some cases it will do multiple requests
* Coolsms only support one destination per request. That means each destination in recipients option will be a request.


I am happy to discuss, change or add stuff you feel is missing or could be better :)

